### PR TITLE
Minor fixes to install process.

### DIFF
--- a/bin/install_minecraft.sh
+++ b/bin/install_minecraft.sh
@@ -14,15 +14,16 @@ cd /etc/minecraft
 sudo wget -O minecraft_server.jar https://s3.amazonaws.com/Minecraft.Download/versions/1.8.7/minecraft_server.1.8.7.jar
 
 # Install minecraft overviewer
+echo "deb http://overviewer.org/debian ./" | sudo tee -a /etc/apt/sources.list
 wget -O - http://overviewer.org/debian/overviewer.gpg.asc | sudo apt-key add -
 sudo apt-get update
-apt-get install minecraft-overviewer
+sudo apt-get install minecraft-overviewer
 
 # return to bin dir
 cd ${SCRIPTPATH}
 
 # Install minecraft init.d script
-cp ./minecraft_service.sh /etc/init.d/
+sudo cp ./minecraft_service.sh /etc/init.d/minecraft
 
 # Setup backup/map crons
 ./cron_setup.sh


### PR DESCRIPTION
This pull request fixes multiple issues with the installation process:
1. The Overviewer apt source was not added to the sources list, resulting in apt not being able to find Overviewer.
2. The `minecraft_service.sh` script was not copied to the init.d folder using the proper filename, which is simply `minecraft`. The result was that the user could not run the commands as described in `README.md`.
3. Multiple commands were not being run using `sudo`, resulting in fatal errors.
